### PR TITLE
Get Bundle Thumbnail from the Twitter Card Metadata

### DIFF
--- a/humble.js
+++ b/humble.js
@@ -49,7 +49,11 @@ async function get_bundle_metadata(page) {
   let info = JSON.parse(cleanJSON);
   let ends_at = info.offers.availabilityEnds + "Z";
 
+  let thumbnail_elem = await page.$("meta[name='twitter:image']");
+  let thumbnail_url = await thumbnail_elem.getAttribute("content");
+
   return {
+    thumbnail_url,
     logo_url,
     logo_alt,
     headline,


### PR DESCRIPTION
Hello,

I remarked that currently the API returns the bundle logo which is good, but doesn't return a visual preview of it, like a thumbnail.
So I search in the metadata of bundle pages and found that there is Twitter Card metadata.
If we get the image from the Twitter Card we have what I call a thumbnail of the bundle.

I think it may be a good feature to add. So I added it.